### PR TITLE
Upgrade media manage plugin form theme to use mime types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,12 @@
         "phpunit/phpunit": "^10.5",
         "phpmd/phpmd": "^2.15"
     },
+    "suggest": {
+        "monsieurbiz/sylius-media-manager-plugin": "To use the media manager in the ui elements"
+    },
+    "conflict": {
+        "monsieurbiz/sylius-media-manager-plugin": "<1.2.2"
+    },
     "prefer-stable": true,
     "autoload": {
         "psr-4": {

--- a/dist/templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig
+++ b/dist/templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig
@@ -8,7 +8,7 @@
                     <img src="{{ form.vars.value ? monsieurbiz_richeditor_get_media_without_upload_dir(form.vars.value)|imagine_filter('monsieurbiz_sylius_media_manager_uploaded_image', {"relative_resize": {"widen": filterWidth }}) : '' }}" alt="" style="max-width: 300px;max-height: 300px;" />
                 </p>
             </div>
-            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}', '{{ mimeTypes|escape('js') }}');">
                 {{ 'monsieurbiz_sylius_media_manager.ui.choose_image' | trans }}
             </button>
             <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
@@ -36,12 +36,12 @@
             <div class="monsieurbiz-sylius-file-manager__current" {%- if form.vars.value is empty -%}style="display: none;"{%- endif -%}>
                 <p>
                     <small>{{ 'monsieurbiz_sylius_media_manager.ui.current_video' | trans }}</small><br />
-                     <video width="320" height="240" controls>
+                    <video width="320" height="240" controls>
                         <source src="{{ form.vars.value ? videoSrc : '' }}">
                     </video>
                 </p>
             </div>
-            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}', '{{ mimeTypes|escape('js') }}');">
                 {{ 'monsieurbiz_sylius_media_manager.ui.choose_video' | trans }}
             </button>
             <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
@@ -63,7 +63,7 @@
                     </a>
                 </p>
             </div>
-            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}', '{{ mimeTypes|escape('js') }}');">
                 {{ 'monsieurbiz_sylius_media_manager.ui.choose_file' | trans }}
             </button>
             <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
@@ -83,7 +83,7 @@
                     <img src="{{ form.vars.value ? monsieurbiz_richeditor_get_media_without_upload_dir(form.vars.value)|imagine_filter('monsieurbiz_sylius_media_manager_uploaded_image', {"relative_resize": {"widen": filterWidth }}) : '' }}" alt="" style="max-width: 40px;max-height: 40px;" />
                 </p>
             </div>
-            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}', '{{ mimeTypes|escape('js') }}');">
                 {{ 'monsieurbiz_sylius_media_manager.ui.choose_image' | trans }}
             </button>
             <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
@@ -105,7 +105,7 @@
                     </audio>
                 </p>
             </div>
-            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}', '{{ mimeTypes|escape('js') }}');">
                 {{ 'monsieurbiz_sylius_media_manager.ui.choose_file' | trans }}
             </button>
             <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>


### PR DESCRIPTION
To ensure using the version of the media manager plugin that supports mime types: https://github.com/monsieurbiz/SyliusMediaManagerPlugin/releases/tag/v1.2.2

Example with require the wrong version:
![image](https://github.com/user-attachments/assets/15fd703a-07cb-4bae-818a-289419ec46b1)
