### PR TITLE
[DX] Allow installing the plugin on Sylius 2.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "sylius/sylius": "~2.0.0",
+        "sylius/sylius": "~2.0.0 || ~2.1.0",
         "twig/markdown-extra": "^3.13",
         "twig/extra-bundle": "^3.13",
         "league/commonmark": "^2.6"


### PR DESCRIPTION
This pull request updates the `composer.json` file to expand the compatibility of the `sylius/sylius` dependency to include version `~2.1.0`.

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L9-R9): Updated the `sylius/sylius` dependency to support both `~2.0.0` and `~2.1.0` versions, enhancing compatibility with newer versions of Sylius.