### PR TITLE
fix(youtube): accept share links, query params, country TLDs and subdomains

### DIFF
--- a/src/Validator/Constraints/YoutubeUrlValidator.php
+++ b/src/Validator/Constraints/YoutubeUrlValidator.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class YoutubeUrlValidator extends ConstraintValidator
 {
-    public const YOUTUBE_REGEX_VALIDATOR = '`^(?:https?://)?(?:www\.)?(?:youtu.be/|youtube\.com/(?:watch(?:/|/?\?(?:\S*&)?v=)|embed/|shorts/))([\w\d-]+)$`';
+    public const YOUTUBE_REGEX_VALIDATOR = '`^(?:https?://)?(?:[a-z0-9-]+\.)*(?:youtu\.be/|youtube\.[a-z0-9.-]+/(?:watch(?:/|/?\?(?:\S*&)?v=)|embed/|shorts/))([\w\d-]+)(?:[?&#]\S*)?$`i';
 
     public function validate(mixed $value, Constraint $constraint): void
     {


### PR DESCRIPTION
### Problem

`YoutubeUrlValidator::YOUTUBE_REGEX_VALIDATOR` is the single source of truth for both the form validation and the iframe rendering (`RichEditorExtension::getYoutubeIdFromLink()` / `convertYoutubeEmbeddedLink()`). Its trailing `$` right after the id rejects the query params YouTube now appends by default, and the host part only matches `youtube.com`:

- `https://youtu.be/<id>?si=...` — the `?si=` share token added by default on "Copy link"
- `https://www.youtube.com/watch?v=<id>&t=42` — timestamped links
- `https://www.youtube.fr/watch?v=<id>` — country TLDs
- `https://m.youtube.com/watch?v=<id>` — mobile / `music.` links

Example that currently fails: `https://youtu.be/ZJbn2i9W4L8?si=ET9SknJlGjR3vrKO`

### Fix

A single change to the existing regex constant (so both validation and rendering are fixed at once, and it stays the one source of truth):

- allow a trailing query/fragment after the id: `([\w\d-]+)(?:[?&#]\S*)?$`
- accept any TLD: `youtube\.[a-z0-9.-]+`
- accept leading subdomains (`m.`, `music.`, …): `(?:[a-z0-9-]+\.)*`
- match the host case-insensitively (`i` flag)
- escape the dot in `youtu\.be`

Empty values are still left to `NotBlank` (unchanged early return).

Verified against: `watch?v=`, `youtu.be/`, `/embed/`, `/shorts/`, with and without `?si=`/`&t=`, with and without `www.`, `http`/`https`, scheme-less, `m.`/`music.` subdomains, country and IDN/punycode TLDs, uppercase hosts — and correctly rejecting non-YouTube hosts (`vimeo.com`, `notyoutube.com`, `myyoutube.com`), `watch` without `v`, and malformed ids.
